### PR TITLE
fix for call to missing method AffinePoint.double() while adding iden…

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -421,6 +421,8 @@ class AffinePoint(object):
         R = r.to_affine()
         assert R.on_curve
         return R
+    def double(self):
+        return self.__mul__(gmpy.mpz(2))
     def __add__(self, other):
         if not isinstance(other, AffinePoint):
             raise NotImplementedError


### PR DESCRIPTION
fix for call to missing method AffinePoint.double() while adding identical points.

An error occurs when adding Affine Points P + P as it is implemented as a call to double() which does not exist. 

Fix proposed by implementing double() via the multiplication operator: 2*P
