### PR TITLE
Set the outlen for serialize_number() when signing

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -655,8 +655,10 @@ class PrivKey(object):
 
     def sign(self, h, sig_format=SER_BINARY):
         """ Signs the message with SHA-512 hash `h' with this private key. """
+        outlen = (self.curve.sig_len_compact if sig_format == SER_COMPACT
+                  else self.curve.sig_len_bin)
         sig = self._ECDSA_sign(h)
-        return serialize_number(sig, sig_format)
+        return serialize_number(sig, sig_format, outlen)
 
     def __repr__(self):
         return "<PrivKey %s>" % self.e

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -50,6 +50,12 @@ class TestMain(unittest.TestCase):
         self.assertEqual(seccure.sign(msg, pw),
                          b'$HPI?t(I*1vAYsl$|%21WXND=6Br*[>k(OR9B!GOwHqL0s+3Uq')
 
+    def test_sign_length(self):
+        msg = b'ttrMWDqBxjC8UAl8X4TRDSSpd1IyYMh4\n'
+        pw = b'my private key'
+        self.assertEqual(seccure.sign(msg, pw),
+                         b'!!!5{LV[=|t~46wS2y<Ub9Ol;uO/fPGU*JYKid+|(JBMspwk7S')
+
     def test_sign_and_verify(self):
         msg = b'This message will be signed\n'
         pw = b'my private key'


### PR DESCRIPTION
I noticed that signatures generated by `seccure` wouldn't match py-secure's `sign()` if they began with an exclamation mark. Since `!` is zero in your base-90 representation, I assumed it was a padding issue. It turns out that `sign()` doesn't set the `outlen` argument when calling `serialize_number()`.

I added code to fix this very similar to how it's done in [to_bytes()](https://github.com/bwesterb/py-seccure/blob/master/src/__init__.py#L518). You can reproduce the bug with the following code:

```
import seccure

msg = b'ttrMWDqBxjC8UAl8X4TRDSSpd1IyYMh4\n'
pw = b'my private key'
sig = seccure.sign(msg, pw)
print(sig.decode())
```
It will print `5{LV[=|t~46wS2y<Ub9Ol;uO/fPGU*JYKid+|(JBMspwk7S`. Compare it to the output of `seccure`:
```
seccure-sign -F <(echo 'my private key') -i <(echo 'ttrMWDqBxjC8UAl8X4TRDSSpd1IyYMh4')
```
Which generates the signature `!!!5{LV[=|t~46wS2y<Ub9Ol;uO/fPGU*JYKid+|(JBMspwk7S`.

I wrote a test for the changes in `src/tests/test_main.py`.

I assign all copyright for the changes to you :)
